### PR TITLE
untagged profile fields variant

### DIFF
--- a/objects/user_profile.json
+++ b/objects/user_profile.json
@@ -42,25 +42,37 @@
       "type": "string"
     },
     "fields": {
-      "type": "object",
-      "properties": {},
-      "patternProperties": {
-        "^.+$": {
+      "oneOf": [
+        {
+          "title": "fields",
           "type": "object",
-          "properties": {
-            "value": {
-                "type": "string"
-            },
-            "alt": {
-                "type": "string"
-            },
-            "label": {
-                "type": "string"
+          "properties": {},
+          "patternProperties": {
+            "^.+$": {
+              "type": "object",
+              "properties": {
+                "value": {
+                  "type": "string"
+                },
+                "alt": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              }
             }
+          },
+          "additionalProperties": false
+        },
+        {
+          "title": "Empty",
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
-      },
-      "additionalProperties": false
+      ]
     }
   },
   "id": "user_profile"


### PR DESCRIPTION
profile fiends can be null, [], or an object representing a map
there is no type field that indicates which it will be so it needs to use new untagged type