### PR TITLE
Fix scraper script

### DIFF
--- a/api_scraper/index.js
+++ b/api_scraper/index.js
@@ -702,7 +702,7 @@ function getParamTypeFromExample(method, name, example) {
   const known_value = KNOWN_PARAM_TYPES.has(method)
     ? KNOWN_PARAM_TYPES.get(method).get(name)
     : null;
-  
+
   if (known_value !== null) {
     return known_value;
   } else {
@@ -823,12 +823,12 @@ async.parallel([
     parseSlackApi((modules) => {
       modules.forEach(mod => {
         if (mod.name === "chat") {
-          mod.methods.find(method => method.name === "chat.update").response.sample 
+          mod.methods.find(method => method.name === "chat.update").response.sample
             = '{ "ok": true, "channel": "C024BE91L", "ts": "1401383885.000061", "text": "Updated Text" }';
         }
         if (mod.name === "files") {
           mod.methods.find(method => method.name === "files.sharedPublicURL").response.sample = '{"ok":true,"file":{"id":"F2147483862","timestamp":1356032811,"name":"file.htm","title":"My HTML file","mimetype":"text/plain","filetype":"text","pretty_type":"Text","user":"U2147483697","mode":"hosted","editable":true,"is_external":false,"external_type":"","size":12345,"url":"https://slack-files.com/files-pub/T024BE7LD-F024BERPE-09acb6/1.png","url_download":"https://slack-files.com/files-pub/T024BE7LD-F024BERPE-09acb6/download/1.png","url_private":"https://slack.com/files-pri/T024BE7LD-F024BERPE/1.png","url_private_download":"https://slack.com/files-pri/T024BE7LD-F024BERPE/download/1.png","thumb_64":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_64.png","thumb_80":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_80.png","thumb_360":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_360.png","thumb_360_gif":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_360.gif","thumb_360_w":100,"thumb_360_h":100,"permalink":"https://tinyspeck.slack.com/files/cal/F024BERPE/1.png","permalink_public":"https://slack-files.com/T024BE7LD-F024BERPE-8004f909b1","edit_link":"https://tinyspeck.slack.com/files/cal/F024BERPE/1.png/edit","preview":"&lt;!DOCTYPE html&gt;\\n&lt;html&gt;\\n&lt;meta charset=\'utf-8\'&gt;","preview_highlight":"&lt;div class=\\"sssh-code\\"&gt;&lt;div class=\\"sssh-line\\"&gt;&lt;pre&gt;&lt;!DOCTYPE html","lines":123,"lines_more":118,"is_public":false,"public_url_shared":false,"channels":["C024BE7LT"],"groups":["G12345"],"initial_comment":{},"num_stars":7,"is_starred":true}}';
-          mod.methods.find(method => method.name === "files.revokePublicURL").response.sample 
+          mod.methods.find(method => method.name === "files.revokePublicURL").response.sample
             = '{"ok":true,"file":{"id":"F2147483862","timestamp":1356032811,"name":"file.htm","title":"My HTML file","mimetype":"text/plain","filetype":"text","pretty_type":"Text","user":"U2147483697","mode":"hosted","editable":true,"is_external":false,"external_type":"","size":12345,"url":"https://slack-files.com/files-pub/T024BE7LD-F024BERPE-09acb6/1.png","url_download":"https://slack-files.com/files-pub/T024BE7LD-F024BERPE-09acb6/download/1.png","url_private":"https://slack.com/files-pri/T024BE7LD-F024BERPE/1.png","url_private_download":"https://slack.com/files-pri/T024BE7LD-F024BERPE/download/1.png","thumb_64":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_64.png","thumb_80":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_80.png","thumb_360":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_360.png","thumb_360_gif":"https://slack-files.com/files-tmb/T024BE7LD-F024BERPE-c66246/1_360.gif","thumb_360_w":100,"thumb_360_h":100,"permalink":"https://tinyspeck.slack.com/files/cal/F024BERPE/1.png","permalink_public":"https://slack-files.com/T024BE7LD-F024BERPE-8004f909b1","edit_link":"https://tinyspeck.slack.com/files/cal/F024BERPE/1.png/edit","preview":"&lt;!DOCTYPE html&gt;\\n&lt;html&gt;\\n&lt;meta charset=\'utf-8\'&gt;","preview_highlight":"&lt;div class=\\"sssh-code\\"&gt;&lt;div class=\\"sssh-line\\"&gt;&lt;pre&gt;&lt;!DOCTYPE html","lines":123,"lines_more":118,"is_public":false,"public_url_shared":false,"channels":["C024BE7LT"],"groups":["G12345"],"initial_comment":{},"num_stars":7,"is_starred":true}}';
         }
         mod.methods.forEach(method => {
@@ -944,7 +944,7 @@ async.parallel([
         //         "title": "file"
         //       },
         //       {
-                
+
         //       },
         //       {
 


### PR DESCRIPTION
(Fixes #7)

The scraper script crashes with this error:

```
undefined:1



SyntaxError: Unexpected end of input
    at Object.parse (native)
    at /home/ben/slack-api-schemas/api_scraper/index.js:877:56
```

This happens because [the `reply_broadcast` docs](https://api.slack.com/events/message/reply_broadcast) does not have a sample anymore since the message has been removed.

> The `reply_broadcast` message subtype is no longer served. It has been replaced with `thread_broadcast`.

Second problem is that [the `thread_broadcast` message](https://api.slack.com/events/message/thread_broadcast) has unbalanced curly braces in the sample (it's missing a closing brace for the `message` object).