### PR TITLE
Changed `channel.priority` to `number`

### DIFF
--- a/objects/channel.json
+++ b/objects/channel.json
@@ -99,7 +99,7 @@
       "type": "boolean"
     },
     "priority": {
-      "type": "integer"
+      "type": "number"
     },
     "is_moved": {
       "type": "integer"


### PR DESCRIPTION
The `priority` is set to an `integer`, but actually it's a `number` as
it can be a floating point value.

So it's updated.