### PR TITLE
skip message types that have been deprecated

### DIFF
--- a/api_scraper/index.js
+++ b/api_scraper/index.js
@@ -873,7 +873,7 @@ async.parallel([
             ]
         })
       });
-      messageTypes.forEach((messageType) => {
+      messageTypes.filter((messageType) => messageType.sample !== "").forEach((messageType) => {
         const messageSchema = GenerateSchema.json(JSON.parse(sanitizeResponse(messageType.name, messageType.sample)));
         messageSchema.title = messageType.name;
         messageSchema["$schema"] = undefined;


### PR DESCRIPTION
script was failing on message type https://api.slack.com/events/message/reply_broadcast that is "No longer served"